### PR TITLE
feat: support more JavaScript than just function in grid_options

### DIFF
--- a/docs/notebooks/demo-ipyaggrid-javascript.ipynb
+++ b/docs/notebooks/demo-ipyaggrid-javascript.ipynb
@@ -1,0 +1,100 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a309447d",
+   "metadata": {},
+   "source": [
+    "# Use javascript in `grid_options` by using `__js__:` prefix"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "614ccb50",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ipyaggrid import Grid\n",
+    "\n",
+    "grid = Grid(\n",
+    "    css_rules=\"\"\"\n",
+    "        .ag-cell-not-inline-editing.price-high {\n",
+    "          background-color: red;\n",
+    "          color: white;\n",
+    "        }\n",
+    "        .my-tooltip {\n",
+    "          background-color: white;\n",
+    "          border: 1px solid black;\n",
+    "          padding: 8px;\n",
+    "        }\n",
+    "    \"\"\",\n",
+    "    grid_data=[\n",
+    "        {\"make\": \"Toyota\", \"model\": \"Celica\", \"price\": 35000},\n",
+    "        {\"make\": \"Ford\", \"model\": \"Mondeo\", \"price\": 32000},\n",
+    "        {\"make\": \"Porsche\", \"model\": \"Boxster\", \"price\": 72000},\n",
+    "    ],\n",
+    "    grid_options={\n",
+    "        'columnDefs': [\n",
+    "            {\"headerName\": \"Make\", \"field\": \"make\", \"editable\": True},\n",
+    "            {\"headerName\": \"Model\", \"field\": \"model\", \"editable\": True},\n",
+    "            {\"headerName\": \"Price\", \"field\": \"price\", \"editable\": True, 'type': 'numericColumn',\n",
+    "             'cellClass': \"\"\"function(params) {\n",
+    "               return params.value >32000 ? 'price-high' : '';\n",
+    "             }\"\"\",\n",
+    "             \"tooltipField\": 'price',\n",
+    "             \"tooltipComponent\": \"\"\"__js__: class {\n",
+    "               init(params) {\n",
+    "                 const eGui = this.eGui = document.createElement('div');\n",
+    "                   \n",
+    "                 if (params.value > 32000) {\n",
+    "                   eGui.classList.add('my-tooltip');\n",
+    "                   eGui.innerHTML = 'value to high';                           \n",
+    "                 }\n",
+    "               }\n",
+    "               \n",
+    "               getGui() {\n",
+    "                 return this.eGui;\n",
+    "               }\n",
+    "             }\"\"\",\n",
+    "             }\n",
+    "        ],\n",
+    "        'tooltipShowDelay': 0,\n",
+    "        'tooltipHideDelay': 2000,\n",
+    "    },\n",
+    ")\n",
+    "\n",
+    "grid"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2ffb64ae",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/js/src/widget_json.js
+++ b/js/src/widget_json.js
@@ -20,6 +20,8 @@ JSONfunc.parse = function(str, helpers) {
         } else if (valueCompact.substring(0, 8) === 'helpers.') {
             r = eval(value);
             return r;
+        } else if (valueCompact.startsWith('__js__:')) {
+            return Function(`"use strict"; return (${value.slice(7)})`)();
         }
         return value;
     });


### PR DESCRIPTION
This PR allows for more than only `function` or `helpers.` to be evaluated as JavaScript. The new `__js__:` prefix allows for any JavaScript.  

Example:
```python
from ipyaggrid import Grid

grid = Grid(
    css_rules="""
        .ag-cell-not-inline-editing.price-high {
          background-color: red;
          color: white;
        }
        .my-tooltip {
          background-color: white;
          border: 1px solid black;
          padding: 8px;
        }
    """,
    grid_data=[
        {"make": "Toyota", "model": "Celica", "price": 35000},
        {"make": "Ford", "model": "Mondeo", "price": 32000},
        {"make": "Porsche", "model": "Boxster", "price": 72000},
    ],
    grid_options={
        'columnDefs': [
            {"headerName": "Make", "field": "make", "editable": True},
            {"headerName": "Model", "field": "model", "editable": True},
            {"headerName": "Price", "field": "price", "editable": True, 'type': 'numericColumn',
             'cellClass': """function(params) {
               return params.value >32000 ? 'price-high' : '';
             }""",
             "tooltipField": 'price',
             "tooltipComponent": """__js__: class {
               init(params) {
                 const eGui = this.eGui = document.createElement('div');
                   
                 if (params.value > 32000) {
                   eGui.classList.add('my-tooltip');
                   eGui.innerHTML = 'value to high';                           
                 }
               }
               
               getGui() {
                 return this.eGui;
               }
             }""",
             }
        ],
        'tooltipShowDelay': 0,
        'tooltipHideDelay': 2000,
    },
)

grid
```