### PR TITLE
feat: add method to update cells without resetting the undo stack

### DIFF
--- a/ipyaggrid/grid.py
+++ b/ipyaggrid/grid.py
@@ -72,6 +72,7 @@ class Grid(wg.DOMWidget):
     license = Unicode('').tag(sync=True)
 
     grid_data_out = Dict({}).tag(sync=False)
+    _cell_updates = List([]).tag(sync=True)
 
     params = []
 
@@ -325,3 +326,17 @@ class Grid(wg.DOMWidget):
         dic = json.loads(self.js_helpers)
         for k, v in dic.items():
             print('\n' + k+' : '+v)
+
+    def update_cells(self, updates):
+        """
+        Updates specific cells of the grid. Preserves the undo/redo stack.
+
+        ## Arguments
+
+        * `updates`: list of dicts, each dict containing the row_id, field and value of a cell. e.g:
+            [{"row_id": 0, "field": "model", "value": "new value"},
+             {"row_id": 0, "field": "model", "value": "another new value"}]
+
+        Note: row_id is the index of the row, this can be changed by setting 'getRowNodeId' in 'grid_options'.
+        """
+        self._cell_updates = updates

--- a/js/src/widget_builder.js
+++ b/js/src/widget_builder.js
@@ -203,6 +203,15 @@ const buildAgGrid = (view, gridData, gridOptions_str, div, sheet, dropdownMulti 
     if (view.model.get('sync_grid')) {
         exportFunc.exportGrid(gridOptions, view);
     }
+
+    // update cells
+    view.model.on('change:_cell_updates', () => {
+        view.model.get('_cell_updates').forEach(({row_id, field, value}) => {
+            const rowNode = gridOptions.api.getRowNode(row_id);
+            rowNode.setDataValue(field, value);
+        });
+        view.model.set('_cell_updates', [])
+    });
 };
 
 /**

--- a/js/src/widget_grid.js
+++ b/js/src/widget_grid.js
@@ -76,6 +76,7 @@ const AgGridModel = widgets.DOMWidgetModel.extend(
 
                 _counter_update_data: 0,
                 _export_mode: '',
+                _cell_updates: [],
             });
         },
     },


### PR DESCRIPTION
Example:
```python
from ipyaggrid import Grid

grid = Grid(
    grid_data=[
        {"make": "Toyota", "model": "Celica", "price": 35000},
        {"make": "Ford", "model": "Mondeo", "price": 32000},
        {"make": "Porsche", "model": "Boxster", "price": 72000},
        {"make": "", "model": "Total", "price": 0},
    ],
    grid_options={
        'columnDefs': [
            {"headerName": "Make", "field": "make", "editable": True},
            {"headerName": "Model", "field": "model", "editable": True},
            {"headerName": "Price", "field": "price", "editable": True, 'type': 'numericColumn'},
        ],
        'undoRedoCellEditing': True,
        'undoRedoCellEditingLimit': 20,
    },
    sync_on_edit=True,
    menu={"buttons": [
        {
            'name':'undo',
            'action':'gridOptions.api.undoCellEditing()',
        }, {
            'name':'redo',
            'action':'gridOptions.api.redoCellEditing()',
        }
    ]}
)

def update_total(change):
    df_grid = change['new']["grid"]
    total = df_grid["price"].head(3).astype(int).sum()
    
    grid.update_cells([{"row_id": 3, "field": "price", "value": total}])

    
grid.observe(update_total, names='grid_data_out')

grid
```