### PR TITLE
fix: ipywidgets 8 support

### DIFF
--- a/ipyaggrid/grid.py
+++ b/ipyaggrid/grid.py
@@ -59,7 +59,7 @@ class Grid(wg.DOMWidget):
         sync=True, to_json=Util.options_to_json)
     js_helpers_custom = Unicode('').tag(
         sync=True, to_json=Util.options_to_json)
-    js_helpers = Unicode('').tag(sync=True, to_json=Util.options_to_json)
+    js_helpers = Unicode('').tag(sync=True)
     js_pre_helpers = List([]).tag(sync=True)
     js_pre_grid = List([]).tag(sync=True)
     js_post_grid = List([]).tag(sync=True)

--- a/js/.babelrc
+++ b/js/.babelrc
@@ -1,3 +1,12 @@
 {
-  "presets": ["env"]
+  "presets": [
+    [
+      "@babel/preset-env",
+      {
+        "useBuiltIns": "usage",
+        "corejs": 3,
+        "modules": false
+      }
+    ]
+  ]
 }

--- a/js/package.json
+++ b/js/package.json
@@ -45,8 +45,8 @@
         "build:labextension:dev": "jupyter labextension build --development True ."
     },
     "dependencies": {
-        "@jupyter-widgets/base": "^3.0.0",
-        "@jupyter-widgets/controls": "^2.0.0",
+        "@jupyter-widgets/base": "^3.0.0 || ^4 || ^6",
+        "@jupyter-widgets/controls": "^2.0.0 || ^3 || ^4 || ^5",
         "ag-grid-community": "28.1.1",
         "ag-grid-enterprise": "28.1.1",
         "d3": "^5.9.7",
@@ -54,10 +54,9 @@
         "pako": "^1.0.10"
     },
     "devDependencies": {
+        "@babel/core": "^7.4.4",
+        "@babel/preset-env": "^7.4.4",
         "@jupyterlab/builder": "^3.2.3",
-        "babel-core": "^6.26.3",
-        "babel-loader": "^7.1.5",
-        "babel-preset-env": "^1.7.0",
         "css-loader": "^3.1.0",
         "eslint": "^5.16.0",
         "eslint-config-airbnb": "^17.1.1",

--- a/js/src/widget_grid.js
+++ b/js/src/widget_grid.js
@@ -24,11 +24,11 @@ import './styles/menu_div.css';
 
 const semver_range = `~${version}`;
 
-const AgGridModel = widgets.DOMWidgetModel.extend(
-    {
-        defaults() {
-            return extend(AgGridModel.__super__.defaults.call(this), {
-                _model_name: 'AgGridModel',
+class AgGridModel extends widgets.DOMWidgetModel {
+    defaults() {
+        return {
+            ...super.defaults(),
+            ...{                _model_name: 'AgGridModel',
                 _view_name: 'AgGridView',
                 _model_module: 'ipyaggrid',
                 _view_module: 'ipyaggrid',
@@ -77,26 +77,22 @@ const AgGridModel = widgets.DOMWidgetModel.extend(
                 _counter_update_data: 0,
                 _export_mode: '',
                 _cell_updates: [],
-            });
-        },
-    },
-    {
-        serializers: _.extend(
-            {
-                _grid_data_down: { deserialize: Utils.deserialize_data },
-                _grid_data_up: { serialize: Utils.serialize_data },
-                _grid_options_mono_down: { deserialize: Utils.deserialize_options },
-                _grid_options_multi_down: { deserialize: Utils.deserialize_multi_options },
-                _js_helpers_builtin: { deserialize: Utils.deserialize_options },
-                js_helpers: { deserialize: Utils.deserialize_options },
-                js_helpers_custom: { deserialize: Utils.deserialize_options },
             },
-            widgets.DOMWidgetModel.serializers
-        ),
+        };
     }
-);
+}
 
-const AgGridView = widgets.DOMWidgetView.extend({
+AgGridModel.serializers = {
+    ...widgets.DOMWidgetModel.serializers,
+    _grid_data_down: { deserialize: Utils.deserialize_data },
+    _grid_data_up: { serialize: Utils.serialize_data },
+    _grid_options_mono_down: { deserialize: Utils.deserialize_options },
+    _grid_options_multi_down: { deserialize: Utils.deserialize_multi_options },
+    _js_helpers_builtin: { deserialize: Utils.deserialize_options },
+    js_helpers_custom: { deserialize: Utils.deserialize_options },
+};
+
+class AgGridView extends widgets.DOMWidgetView {
     render() {
         this._id = this.model.get('_id');
         const div_widget = this.el;
@@ -137,7 +133,7 @@ const AgGridView = widgets.DOMWidgetView.extend({
             );
         }
         console.log('end ipyaggrid render');
-    },
-});
+    }
+}
 
 export { AgGridModel, AgGridView };

--- a/js/webpack.config.js
+++ b/js/webpack.config.js
@@ -6,7 +6,6 @@ const { version } = require('./package.json');
 const rules = [
     { test: /\.scss$/, use: ['style-loader', 'css-loader', 'sass-loader'] },
     { test: /\.css$/, use: ['style-loader', 'css-loader'] },
-    { test: /\.js$/, loader: 'babel-loader', exclude: /node_modules/ },
     {
         test: /\.svg$/,
         use: [

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-ipywidgets>=7.4.0,<8.0
+ipywidgets>=7.4.0
 pandas
 simplejson>=3.13.2


### PR DESCRIPTION
Ipywidgets 8 requires es6 class notation for models and views. This required an upgrade of babel.

The js_helpers serializer was removed, because it was not base64 encoded. It only resulted in an error on ipywidgets 8 because of
the new echo functionality: https://ipywidgets.readthedocs.io/en/latest/changelog.html?highlight=echo#collaboration