### PR TITLE
Remove filter on root node to enable row groups

### DIFF
--- a/js/src/widget_export.js
+++ b/js/src/widget_export.js
@@ -243,9 +243,7 @@ function getProcessedNodes(options) {
         nodes.push(node);
     });
     options.api.forEachNodeAfterFilterAndSort(node => {
-        if (node.parent.id === 'ROOT_NODE_ID') {
-            res.push(cleanNode(node, columns.columns_keys));
-        }
+        res.push(cleanNode(node, columns.columns_keys));
     });
     return { data: res, values: columns.columns_headers };
 }


### PR DESCRIPTION
Tables with row groupings currently display but do not emit change events due to a filter removing any event coming from a cell not a direct child of the root node.  Removing filter enables these change events.  (Unclear why filter was in place)