### PR TITLE
Add source distribution files to build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
       - name: build js
         run: (cd js && npm install && npm run build:labextension)
       - name: Package
-        run: python setup.py bdist_wheel --universal
+        run: python setup.py sdist bdist_wheel --universal
       - name: Test Package
         run: pip install dist/*.whl && python -c "import ipyaggrid"
       - name: Publish a Python distribution to S3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: build js
         run: (cd js && npm install && npm run build:labextension)
       - name: Package
-        run: python setup.py bdist_wheel --universal
+        run: python setup.py sdist bdist_wheel --universal
       - name: Test Package
         run: pip install dist/*.whl && python -c "import ipyaggrid"
       - name: Publish the NPM package


### PR DESCRIPTION
The source distribution files are missing in pypi (https://pypi.org/project/ipyaggrid/0.3.1/#files)

Because of that we can't use grayskull to add ipyaggrid to conda forge (https://conda-forge.org/docs/maintainer/adding_pkgs.html#generating-the-recipe)

This PR adds the source distribution files in the build pipeline