### PR TITLE
Export rows as displayed with sorting applied

### DIFF
--- a/js/src/widget_export.js
+++ b/js/src/widget_export.js
@@ -60,8 +60,20 @@ exportFunc.exportRangeData = (options, view) => {
 // Export Rows
 
 exportFunc.exportRows = (options, view) => {
-    const rows = options.api.getSelectedNodes();
+    //const rows = options.api.getSelectedNodes();
+    const rows = getSelectedNodesAsDisplayed(options);
     exportRowsFunc(options, view, rows);
+};
+
+const getSelectedNodesAsDisplayed = (options) => {
+    // Returns selected nodes in order as shown in table (with filter, sort, & grouping)
+    const rowNodes = [];
+    options.api.forEachNodeAfterFilterAndSort((node) => {
+        if (!node.group && node.selected) {
+            rowNodes.push(node);
+        }
+    });
+    return rowNodes; 
 };
 
 const exportRowsFunc = (options, view, rows) => {


### PR DESCRIPTION
This change allows the rows to be exported as displayed in the table.  This considers the following:
- only sorted rows are taken (as previous implementation)
- sorting order of the rows is used
- grouped row header is not exported
- collapsed groups are not exported