### PR TITLE
Add sync_on_sort export event

### DIFF
--- a/ipyaggrid/builder_params.py
+++ b/ipyaggrid/builder_params.py
@@ -92,6 +92,9 @@ class BuilderParams:
         msg = 'sync_on_edit must be a boolean'
         assert isinstance(self.obj.sync_on_edit, bool), msg
 
+        msg = 'sync_on_sort must be a boolean'
+        assert isinstance(self.obj.sync_on_sort, bool), msg
+
         msg = 'sync_grid must be a boolean'
         assert isinstance(self.obj.sync_grid, bool), msg
 

--- a/ipyaggrid/grid.py
+++ b/ipyaggrid/grid.py
@@ -50,6 +50,7 @@ class Grid(wg.DOMWidget):
     show_toggle_delete = Bool(False).tag(sync=True)
     show_toggle_edit = Bool(False).tag(sync=True)
     sync_on_edit = Bool(False).tag(sync=True)
+    sync_on_sort = Bool(False).tag(sync=True)
     sync_grid = Bool(True).tag(sync=True)
     export_mode = Unicode('').tag(sync=True)
     _export_mode = Unicode('').tag(sync=True)  # Used for auto-export
@@ -96,6 +97,7 @@ class Grid(wg.DOMWidget):
                  show_toggle_delete=False,
                  show_toggle_edit=False,
                  sync_on_edit=False,
+                 sync_on_sort=False,
                  sync_grid=True,
                  paste_from_excel=False,
                  export_mode='disabled',
@@ -139,6 +141,7 @@ class Grid(wg.DOMWidget):
         self.show_toggle_delete = show_toggle_delete
         self.show_toggle_edit = show_toggle_edit
         self.sync_on_edit = sync_on_edit
+        self.sync_on_sort = sync_on_sort
         self.sync_grid = sync_grid
         self.paste_from_excel = paste_from_excel
         self.js_helpers_custom = js_helpers_custom

--- a/js/src/widget_builder.js
+++ b/js/src/widget_builder.js
@@ -162,6 +162,15 @@ const buildAgGrid = (view, gridData, gridOptions_str, div, sheet, dropdownMulti 
             exportFunc.exportGrid(gridOptions, view);
         });
     }
+    
+    // listen for sort changes
+    if (view.model.get('sync_on_sort')) {
+        window.gridOptions = gridOptions;
+        gridOptions.api.addEventListener('sortChanged', params => {
+            // console.log(params);
+            exportFunc.exportGrid(gridOptions, view);
+        });
+    }
 
     // listen to _grid_data_down
     view.model.on('change:_grid_data_down', () => {

--- a/js/src/widget_grid.js
+++ b/js/src/widget_grid.js
@@ -57,6 +57,7 @@ class AgGridModel extends widgets.DOMWidgetModel {
                 show_toggle_delete: false,
                 show_toggle_edit: false,
                 sync_on_edit: false,
+                sync_on_sort: false,
                 sync_grid: true,
                 menu: {},
                 user_params: {},


### PR DESCRIPTION
This PR allows the update of the grid export when the user sorts the table
- this is a configurable option and is disabled by default: `sync_on_sort = False`