### PR TITLE
Export group columns

### DIFF
--- a/ipyaggrid/grid.py
+++ b/ipyaggrid/grid.py
@@ -227,13 +227,14 @@ class Grid(wg.DOMWidget):
                 if(len(data_up['index_rows']['names']) != 0):
                     to_df['index'] = pd.MultiIndex.from_tuples(
                         *[data_up['index_rows']['values']], names=data_up['index_rows']['names'])
-                if len(data_up['index_columns'][0]) == 1:
-                    index_columns = [elem[0]
-                                     for elem in data_up['index_columns']]
-                    to_df['columns'] = index_columns
-                else:
-                    to_df['columns'] = pd.MultiIndex.from_tuples(
-                        *[data_up['index_columns']])
+                if data_up['index_columns']:
+                    if len(data_up['index_columns'][0]) == 1:
+                        index_columns = [elem[0]
+                                         for elem in data_up['index_columns']]
+                        to_df['columns'] = index_columns
+                    else:
+                        to_df['columns'] = pd.MultiIndex.from_tuples(
+                            *[data_up['index_columns']])
                 to_df['data'] = data_up['data']
                 if self.export_to_df:
                     self.grid_data_out['range'] = pd.DataFrame(**to_df)
@@ -246,13 +247,14 @@ class Grid(wg.DOMWidget):
                 if(len(data_up['index_rows']['names']) != 0):
                     to_df['index'] = pd.MultiIndex.from_tuples(
                         *[data_up['index_rows']['values']], names=data_up['index_rows']['names'])
-                if len(data_up['index_columns'][0]) == 1:
-                    index_columns = [elem[0]
-                                     for elem in data_up['index_columns']]
-                    to_df['columns'] = index_columns
-                else:
-                    to_df['columns'] = pd.MultiIndex.from_tuples(
-                        *[data_up['index_columns']])
+                if data_up['index_columns']:
+                    if len(data_up['index_columns'][0]) == 1:
+                        index_columns = [elem[0]
+                                        for elem in data_up['index_columns']]
+                        to_df['columns'] = index_columns
+                    else:
+                        to_df['columns'] = pd.MultiIndex.from_tuples(
+                            *[data_up['index_columns']])
                 to_df['data'] = data_up['data']
                 if self.export_to_df:
                     self.grid_data_out['cols'] = pd.DataFrame(**to_df)

--- a/ipyaggrid/grid.py
+++ b/ipyaggrid/grid.py
@@ -261,6 +261,26 @@ class Grid(wg.DOMWidget):
                 else:
                     self.grid_data_out['cols'] = pd.DataFrame(
                         **to_df).to_dict(orient='records')
+            if ('groups' in self._grid_data_up.keys()):
+                data_up = self._grid_data_up['groups']
+                to_df = {}
+                if(len(data_up['index_rows']['names']) != 0):
+                    to_df['index'] = pd.MultiIndex.from_tuples(
+                        *[data_up['index_rows']['values']], names=data_up['index_rows']['names'])
+                if data_up['index_columns']:
+                    if len(data_up['index_columns'][0]) == 1:
+                        index_columns = [elem[0]
+                                        for elem in data_up['index_columns']]
+                        to_df['columns'] = index_columns
+                    else:
+                        to_df['columns'] = pd.MultiIndex.from_tuples(
+                            *[data_up['index_columns']])
+                to_df['data'] = data_up['data']
+                if self.export_to_df:
+                    self.grid_data_out['groups'] = pd.DataFrame(**to_df)
+                else:
+                    self.grid_data_out['groups'] = pd.DataFrame(
+                        **to_df).to_dict(orient='records')
             x = 0
             if 'counter' in self.grid_data_out:
                 x = self.grid_data_out['counter']

--- a/js/src/widget_builder.js
+++ b/js/src/widget_builder.js
@@ -140,6 +140,7 @@ const buildAgGrid = (view, gridData, gridOptions_str, div, sheet, dropdownMulti 
             gridOptions.api.updateRowData({ remove: rows });
             if (view.model.get('sync_grid')) {
                 exportFunc.exportGrid(gridOptions, view);
+                exportFunc.exportGroupColumns(gridOptions, view);
             }
         }
         if (view.model.get('_export_mode') === 'rows') {
@@ -148,6 +149,7 @@ const buildAgGrid = (view, gridData, gridOptions_str, div, sheet, dropdownMulti 
         }
         if (view.model.get('_export_mode') === 'grid') {
             exportFunc.exportGrid(gridOptions, view);
+            exportFunc.exportGroupColumns(gridOptions, view);
         }
         if (view.model.get('_export_mode') === 'columns') {
             if (gridOptions.enableRangeSelection) exportFunc.exportColumns(gridOptions, view);
@@ -160,6 +162,12 @@ const buildAgGrid = (view, gridData, gridOptions_str, div, sheet, dropdownMulti 
         gridOptions.api.addEventListener('cellValueChanged', params => {
             // console.log(params);
             exportFunc.exportGrid(gridOptions, view);
+        });
+        gridOptions.api.addEventListener('columnRowGroupChanged', params => {
+            exportFunc.exportGroupColumns(gridOptions, view);
+        });
+        gridOptions.api.addEventListener('rowGroupOpened', params => { // forces sync of state
+            exportFunc.exportGroupColumns(gridOptions, view); 
         });
     }
 
@@ -179,6 +187,7 @@ const buildAgGrid = (view, gridData, gridOptions_str, div, sheet, dropdownMulti 
                     exportFunc.exportRangeData(gridOptions, view);
                     exportFunc.exportColumns(gridOptions, view);
                     exportFunc.exportRowsOfRange(gridOptions, view);
+                    exportFunc.exportGroupColumns(gridOptions, view);
                 // }
             });
         }

--- a/js/src/widget_export.js
+++ b/js/src/widget_export.js
@@ -9,20 +9,16 @@ const exportFunc = {};
  */
 exportFunc.exportRangeData = (options, view) => {
     let rangeSelection;
+    let cols;
     try {
-        console.log(options.api.getCellRanges())
+        //console.log(options.api.getCellRanges())
         rangeSelection = options.api.getCellRanges();
+        rangeSelection = rangeSelection[0];
+        cols = findCorrectColumns(rangeSelection.columns, options);
     } catch (e) {
         console.log('No cells selected.');
         return;
     }
-
-    console.log(rangeSelection)
-    console.log(rangeSelection[0].startRow)
-    console.log(rangeSelection[0].endRow)
-    rangeSelection = rangeSelection[0];
-    console.log(rangeSelection)
-    const cols = findCorrectColumns(rangeSelection.columns, options);
     const rows = [];
 
     const id1 = rangeSelection.startRow.rowIndex;
@@ -52,7 +48,7 @@ exportFunc.exportRangeData = (options, view) => {
             index_columns: res.columns,
         },
     };
-    console.log(toUp);
+    //console.log(toUp);
     view.model.set('_grid_data_up', toUp);
     view.touch();
 };
@@ -87,7 +83,7 @@ const exportRowsFunc = (options, view, rows) => {
             index_columns: res.columns,
         },
     };
-    console.log(toUp);
+    //console.log(toUp);
     view.model.set('_grid_data_up', toUp);
     view.touch();
 };
@@ -149,13 +145,14 @@ function getCol(col, options) {
 
 exportFunc.exportColumns = (options, view) => {
     let rangeSelection;
+    let cols;
     try {
         rangeSelection = options.api.getCellRanges()[0];
+        cols = findCorrectColumns(rangeSelection.columns, options);
     } catch (e) {
         console.log('No cells selected.');
         return;
     }
-    const cols = findCorrectColumns(rangeSelection.columns, options);
     const rows = [];
 
     options.api.forEachNodeAfterFilterAndSort(node => rows.push(node));
@@ -255,7 +252,7 @@ exportFunc.exportGrid = function(options, view, level = 0) {
             index_columns: res.columns,
         },
     };
-    console.log(toUp);
+    //console.log(toUp);
     view.model.set('_grid_data_up', toUp);
     view.touch();
 };

--- a/js/src/widget_export.js
+++ b/js/src/widget_export.js
@@ -181,7 +181,35 @@ exportFunc.exportColumns = (options, view) => {
             index_columns: res.columns,
         },
     };
-    console.log(toUp);
+    //console.log(toUp);
+    view.model.set('_grid_data_up', toUp);
+    view.touch();
+};
+// Export current group columns
+exportFunc.exportGroupColumns = (options, view) => {
+    const columns = [['Group']];
+    const names = ['Index'];
+    const data = [];
+    const values = [];
+    let i = 0;
+    options.columnApi.getRowGroupColumns().forEach(col => {
+        data.push(col.colId);
+        values.push([i++]);
+    });
+    const res = {
+        names,
+        values,
+        data,
+        columns,
+    };
+    const toUp = {
+        groups: {
+            data: res.data,
+            index_rows: { names: res.names, values: res.values },
+            index_columns: res.columns,
+        },
+    };
+    //console.log(toUp);
     view.model.set('_grid_data_up', toUp);
     view.touch();
 };


### PR DESCRIPTION
Allows the current table "grouping" definition to be exported with the grid.  This allows for python-side methods to recognize the grouped state of the table
- Added 'groups' export to the grid.grid_data_out['groups']
- Trapped some errors which occur when column definitions were not known (prevents downstream glitches)
- Reduced some console logging