### PR TITLE
chore: fix nodejs to v16 in CI 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+      - name: Install node
+        uses: actions/setup-node@v3
+        with:
+          node-version: "16.x"
       - name: Set up Python 3.7
         uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
Later versions have an incompatibility with openssl