### PR TITLE
Fix node to v16 in docs build.

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,6 +13,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+      - name: Install node
+        uses: actions/setup-node@v3
+        with:
+          node-version: "16.x"
       - name: Build docs
         run: (cd docs && npm ci && npm run docs:build)
       - name: Add .nojekyll


### PR DESCRIPTION
This is to fix the currently broken build on master: https://github.com/widgetti/ipyaggrid/actions/runs/4532238206/jobs/7983370775

I can have a go at updating the npm dependencies instead if you prefer but used the same quick fix as in https://github.com/widgetti/ipyaggrid/pull/27 for now.