### PR TITLE
Optional dark theme option

### DIFF
--- a/ipyaggrid/builder_params.py
+++ b/ipyaggrid/builder_params.py
@@ -51,6 +51,9 @@ class BuilderParams:
         msg = 'theme must be one of {}'.format(li_theme)
         assert self.obj.theme in li_theme, msg
 
+        msg = 'dark_theme must be one of {} or empty'.format(li_theme)
+        assert self.obj.dark_theme in li_theme or self.obj.dark_theme == '', msg
+
         msg = 'css_rules must be a string'
         assert isinstance(self.obj.css_rules, str), msg
 

--- a/ipyaggrid/grid.py
+++ b/ipyaggrid/grid.py
@@ -33,6 +33,7 @@ class Grid(wg.DOMWidget):
     height = Unicode('').tag(sync=True)
     center = Bool(False).tag(sync=True)
     theme = Unicode('').tag(sync=True)
+    dark_theme = Unicode('').tag(sync=True)
 
     _grid_data_down = List([]).tag(
         sync=True, to_json=Util.data_to_json)
@@ -81,6 +82,7 @@ class Grid(wg.DOMWidget):
                  height=0,
                  center=False,
                  theme='ag-theme-fresh',
+                 dark_theme='',
 
                  grid_data=[],
                  grid_options={},
@@ -120,6 +122,7 @@ class Grid(wg.DOMWidget):
         self.width_in = width
         self.height_in = height
         self.theme = theme
+        self.dark_theme = dark_theme
         self.css_rules = css_rules
         self.quick_filter = quick_filter
         self.export_csv = export_csv

--- a/js/src/widget_builder.js
+++ b/js/src/widget_builder.js
@@ -45,7 +45,13 @@ const buildAgGrid = (view, gridData, gridOptions_str, div, sheet, dropdownMulti 
     div.appendChild(gridDiv);
 
     // Grid style
-    gridDiv.className = view.model.get('theme');
+    const bodyThemeDark = document.body.dataset.jpThemeLight === 'false';
+    const darkTheme = view.model.get('dark_theme');
+    if (bodyThemeDark && darkTheme) {
+        gridDiv.className = view.model.get('dark_theme');
+    } else {
+        gridDiv.className = view.model.get('theme');
+    }
 
     // parse menu param - my contain js
     const menu = JSON.parse(JSON.stringify(view.model.get('menu')));


### PR DESCRIPTION
Hello,

Would it be possible to implement an optional dark theme parameter for the grid to use when the Jupyter server has a dark theme? The below code seems to work for me and is the same as this example here: https://github.com/jupyterlab/jupyterlab/pull/12411/files#diff-066214ffd32187d5dfbe86f20775018b66931dc2e2b3b14b3cb7699a9e0c814a