### PR TITLE
Use defaults when exporting to Excel

### DIFF
--- a/ipyaggrid/js/helpersBuiltin.js
+++ b/ipyaggrid/js/helpersBuiltin.js
@@ -60,23 +60,7 @@ helpersBuiltin = {
      * @param {Object} gridOptions
      */
     exportToCsv: function(gridOptions) {
-        const params = {
-            skipHeader: false,
-            columnGroups: true,
-            skipFooters: false,
-            skipGroups: false,
-            skipPinnedTop: false,
-            skipPinnedBottom: false,
-            allColumns: true,
-            onlySelected: false,
-            suppressQuotes: true,
-            fileName: 'my_file.csv',
-            sheetName: 'my_sheet',
-            shouldRowBeSkipped: () => false,
-            processCellCallback: param => param.value,
-            processHeaderCallback: null,
-        };
-        gridOptions.api.exportDataAsCsv(params);
+        gridOptions.api.exportDataAsCsv();
     },
 
     /**
@@ -84,22 +68,6 @@ helpersBuiltin = {
      * @param {Object} gridOptions
      */
     exportToExcel: function(gridOptions) {
-        const params = {
-            skipHeader: false,
-            columnGroups: true,
-            skipFooters: false,
-            skipGroups: false,
-            skipPinnedTop: false,
-            skipPinnedBottom: false,
-            allColumns: true,
-            onlySelected: false,
-            suppressQuotes: true,
-            fileName: 'my_file.xls',
-            sheetName: 'my_sheet',
-            shouldRowBeSkipped: () => false, // TODO : check
-            processCellCallback: param => param.value,
-            processHeaderCallback: null,
-        };
-        gridOptions.api.exportDataAsExcel(params);
+        gridOptions.api.exportDataAsExcel();
     },
 };


### PR DESCRIPTION
Make the export-to-Excel button behave like the export-to-Excel item in the right-click menu:

![image](https://github.com/widgetti/ipyaggrid/assets/7879276/52dfe51a-c044-4691-b85a-e8e79bc4b754)

Also, this PR solves the annoyance of triggering the download of a file with the wrong extension: xls (wrong) instead of xlsx (right).