### PR TITLE
fix: aggrid doesn't load in Voila>=0.5

### DIFF
--- a/js/src/labplugin.js
+++ b/js/src/labplugin.js
@@ -7,8 +7,8 @@ const id = 'ipyaggrid:plugin';
 const requires = [base.IJupyterWidgetRegistry];
 const autoStart = true;
 
-const baseUrl = JSON.parse(document.getElementById("jupyter-config-data").textContent).baseUrl;
-__webpack_public_path__ = `${baseUrl}lab/extensions/ipyaggrid/static/`;
+const conf = JSON.parse(document.getElementById("jupyter-config-data").textContent);
+__webpack_public_path__ = (conf.fullLabextensionsUrl || `${conf.baseUrl}lab/extensions`) + "/ipyaggrid/static/";
 
 const activate = (app, widgets) => {
     console.log('JupyterLab extension ipyaggrid is activated!');


### PR DESCRIPTION
Voila uses a different location for extensions, which can be found in jupyter-config-data. This setting is also available in Lab, so we should use that. For older versions of Lab there is still a hard coded fallback.